### PR TITLE
pelletier-construction-group_8_7_enable-auto-assign-issues

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,17 @@
+name: Auto-assign Issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pozil/auto-assign-issue@v1
+        with:
+          github-token: ${{ secrets.AUTO_ASSIGN_ISSUE_TOKEN }}
+          assignees: ${{ github.actor }}


### PR DESCRIPTION
resolves #7 

This PR adds the auto-assign-issues.yml which enables a workflow that automatically self-assigns issues to developers upon creation.